### PR TITLE
composer.json refers to upstream not this fork (README.md fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Create a `composer.json` file:
 ```json
 {
     "require": {
-        "besimple/soap": "0.2.*@dev"
+        "tuscanicz/soap": "^4.2"
     }
 }
 ```


### PR DESCRIPTION
Using the composer.json instructions as is will cause the rest of your instructions to fail.  It points to upstream package.  I've got some other changes coming soon.  Happy to help.