### PR TITLE
added carriage return in multipart messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 phpunit.xml
 .idea/
+.project

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "require-dev": {
         "ext-mcrypt": "*",
-        "mikey179/vfsStream": "~1.0",
+        "mikey179/vfsstream": "~1.0",
         "phpunit/phpunit": "~4.0",
         "phpstan/phpstan": "dev-master",
         "phing/phing": "^2.16",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "tuscanicz/soap",
+    "name": "bohrlot/soap",
     "type": "library",
-    "description": "A largely refactored besimple/soap used to build SOAP and WSDL based web services. This fork fixes a lot of errors and provides better API, robust, stable and modern codebase.",
+    "description": "A fixed version of tuscanicz/soap used to build SOAP and WSDL based web services. This fork fixes a mime error in swa messages",
     "keywords": ["soap", "soap server", "soap client"],
     "license": "MIT",
     "authors": [
@@ -20,6 +20,10 @@
         {
             "name": "Petr Bechyně",
             "email": "mail@petrbechyne.com"
+        },
+        {
+            "name": "Francesco Santoro",
+            "email": "santoro@itacatech.it"
         }
     ],
     "require": {
@@ -61,7 +65,7 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/tuscanicz/phpstan.git"
+            "url": "https://github.com/bohrlot/BeSimpleSoap"
         }
     ]
 }

--- a/src/BeSimple/SoapCommon/Mime/MultiPart.php
+++ b/src/BeSimple/SoapCommon/Mime/MultiPart.php
@@ -66,10 +66,10 @@ class MultiPart extends PartHeader
         $message = ($withHeaders === true) ? $this->generateHeaders() : "";
         // add parts
         foreach ($this->parts as $part) {
-            $message .= "\n" . '--' . $this->getHeader('Content-Type', 'boundary') . "\n";
+            $message .= "\r\n" . '--' . $this->getHeader('Content-Type', 'boundary') . "\r\n";
             $message .= $part->getMessagePart();
         }
-        $message .= "\n" . '--' . $this->getHeader('Content-Type', 'boundary') . '--';
+        $message .= "\r\n" . '--' . $this->getHeader('Content-Type', 'boundary') . '--';
 
         return $message;
     }


### PR DESCRIPTION
I noticed that Java servers handle swa messages wrongly due to the lack of a carriage return in the mime part delimiters.
Adding carriage returns appears to solve the issue.